### PR TITLE
fix: update privacy status parsing and ensure case insensitivity

### DIFF
--- a/src/Commands/UpdateCommand.cs
+++ b/src/Commands/UpdateCommand.cs
@@ -115,7 +115,7 @@ namespace YouTubeCLI.Commands
                     {
                         var autoStart = bool.Parse(b[Constants.AutoStart_COLUMN]);
                         var autoStop = bool.Parse(b[Constants.AutoStop_COLUMN]);
-                        var privacy = (PrivacyEnum)Enum.Parse(typeof(PrivacyEnum), b[Constants.Privacy_COLUMN]);
+                        var privacy = (PrivacyEnum)Enum.Parse(typeof(PrivacyEnum), b[Constants.Privacy_COLUMN], true);
 
                         _updateBroadcast(_youTube, b[Constants.YouTubeId_COLUMN], autoStart, autoStop, privacy);
                     }

--- a/src/Libraries/YouTubeLibrary.cs
+++ b/src/Libraries/YouTubeLibrary.cs
@@ -110,7 +110,7 @@ namespace YouTubeCLI.Libraries
             bool testMode = false)
         {
             var _startDate = startsOn ?? DateOnly.FromDateTime(DateTime.Now);
-            
+
             // Validate that start date is not before today
             if (startsOn.HasValue && startsOn.Value < DateOnly.FromDateTime(DateTime.Now))
             {
@@ -153,7 +153,7 @@ namespace YouTubeCLI.Libraries
                         },
                         Status = new LiveBroadcastStatus()
                         {
-                            PrivacyStatus = broadcast.privacy,
+                            PrivacyStatus = broadcast.privacy.ToLower(),
                             // SelfDeclaredMadeForKids = true, going to disable the chat by hand and not use this flag
                         },
                         ContentDetails = new LiveBroadcastContentDetails()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make privacy parsing case-insensitive from CSV and set broadcast PrivacyStatus to lowercase when creating broadcasts.
> 
> - **Commands**:
>   - `src/Commands/UpdateCommand.cs`: Parse `PrivacyEnum` from CSV with case-insensitivity (`Enum.Parse(..., true)`).
> - **YouTube Library**:
>   - `src/Libraries/YouTubeLibrary.cs`: Normalize `Status.PrivacyStatus` to lowercase in `BuildBroadCast` (`broadcast.privacy.ToLower()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 562798d8fa6981e8fbf359738f67488e1704becb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->