### PR TITLE
Enhance List Command

### DIFF
--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -35,7 +35,7 @@ jobs:
         id: git-version
         uses: im-open/git-version-lite@v1
         with:
-          version-from: '2.0.0' # Starting version
+
           bump-major-pattern: '(?i)^(BREAKING CHANGE|!|major):'
           bump-minor-pattern: '(?i)^(feat|feature|minor):'
           bump-patch-pattern: '(?i)^(fix|patch):'

--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -3,21 +3,6 @@ name: Version Management
 on:
   workflow_dispatch:
     inputs:
-      version_type:
-        description: 'Version update type'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-          - prerelease
-      prerelease_label:
-        description: 'Prerelease label (only for prerelease type)'
-        required: false
-        default: 'beta'
-        type: string
       create_pr:
         description: 'Create a pull request with the version update'
         required: false
@@ -37,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # Fetch all history and tags for git-version-lite
 
       - name: Get Current Version
         id: current-version
@@ -46,66 +32,19 @@ jobs:
           echo "Current version: $VERSION"
 
       - name: Calculate New Version
-        id: new-version
-        run: |
-          CURRENT_VERSION="${{ steps.current-version.outputs.current_version }}"
-          VERSION_TYPE="${{ github.event.inputs.version_type }}"
-          PRERELEASE_LABEL="${{ github.event.inputs.prerelease_label }}"
-
-          # Parse current version
-          VERSION_PARTS=(${CURRENT_VERSION//./ })
-          MAJOR=${VERSION_PARTS[0]}
-          MINOR=${VERSION_PARTS[1]}
-          PATCH=${VERSION_PARTS[2]%%-*}
-
-          # Calculate new version based on type
-          case $VERSION_TYPE in
-            "major")
-              NEW_MAJOR=$((MAJOR + 1))
-              NEW_MINOR=0
-              NEW_PATCH=0
-              NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
-              ;;
-            "minor")
-              NEW_MAJOR=$MAJOR
-              NEW_MINOR=$((MINOR + 1))
-              NEW_PATCH=0
-              NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
-              ;;
-            "patch")
-              NEW_MAJOR=$MAJOR
-              NEW_MINOR=$MINOR
-              NEW_PATCH=$((PATCH + 1))
-              NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
-              ;;
-            "prerelease")
-              NEW_MAJOR=$MAJOR
-              NEW_MINOR=$MINOR
-              NEW_PATCH=$PATCH
-              # Check if already a prerelease
-              if [[ $CURRENT_VERSION == *"-"* ]]; then
-                # Extract prerelease part and increment
-                PRERELEASE_PART=${CURRENT_VERSION#*-}
-                PRERELEASE_NUM=${PRERELEASE_PART##*.}
-                if [[ $PRERELEASE_NUM =~ ^[0-9]+$ ]]; then
-                  NEW_PRERELEASE_NUM=$((PRERELEASE_NUM + 1))
-                  NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH-$PRERELEASE_LABEL.$NEW_PRERELEASE_NUM"
-                else
-                  NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH-$PRERELEASE_LABEL.1"
-                fi
-              else
-                NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH-$PRERELEASE_LABEL.1"
-              fi
-              ;;
-          esac
-
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "version_type=$VERSION_TYPE" >> $GITHUB_OUTPUT
-          echo "New version: $NEW_VERSION"
+        id: git-version
+        uses: im-open/git-version-lite@v1
+        with:
+          version-from: '2.0.0' # Starting version
+          bump-major-pattern: '(?i)^(BREAKING CHANGE|!|major):'
+          bump-minor-pattern: '(?i)^(feat|feature|minor):'
+          bump-patch-pattern: '(?i)^(fix|patch):'
+          version-output: 'new_version'
+          version-type-output: 'version_type'
 
       - name: Update Project File
         run: |
-          NEW_VERSION="${{ steps.new-version.outputs.new_version }}"
+          NEW_VERSION="${{ steps.git-version.outputs.new_version }}"
 
           # Update the project file
           sed -i "s/<Version>[^<]*<\/Version>/<Version>$NEW_VERSION<\/Version>/" ${{ env.PROJECT_PATH }}
@@ -120,26 +59,28 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore: bump version to ${{ steps.new-version.outputs.new_version }}'
-          title: 'chore: bump version to ${{ steps.new-version.outputs.new_version }}'
+          commit-message: 'chore: bump version to ${{ steps.git-version.outputs.new_version }}'
+          title: 'chore: bump version to ${{ steps.git-version.outputs.new_version }}'
           body: |
             ## Version Update
 
-            **Version Type**: ${{ steps.new-version.outputs.version_type }}
+            **Version Type**: ${{ steps.git-version.outputs.version_type }}
             **Previous Version**: ${{ steps.current-version.outputs.current_version }}
-            **New Version**: ${{ steps.new-version.outputs.new_version }}
+            **New Version**: ${{ steps.git-version.outputs.new_version }}
+
+            This version was automatically calculated by `im-open/git-version-lite` based on conventional commit messages since the last tag.
 
             ### Changes Made
             - Updated `Version` property in `src/YouTubeCLI.csproj`
-            - Updated `AssemblyVersion` to `${{ steps.new-version.outputs.new_version }}.0`
-            - Updated `FileVersion` to `${{ steps.new-version.outputs.new_version }}.0`
-            - Updated `InformationalVersion` to `${{ steps.new-version.outputs.new_version }}`
+            - Updated `AssemblyVersion` to `${{ steps.git-version.outputs.new_version }}.0`
+            - Updated `FileVersion` to `${{ steps.git-version.outputs.new_version }}.0`
+            - Updated `InformationalVersion` to `${{ steps.git-version.outputs.new_version }}`
 
             ### Next Steps
             1. Review the changes
             2. Merge the pull request
-            3. Create a release with tag `v${{ steps.new-version.outputs.new_version }}`
-          branch: version-bump-${{ steps.new-version.outputs.new_version }}
+            3. Create a release with tag `v${{ steps.git-version.outputs.new_version }}`
+          branch: version-bump-${{ steps.git-version.outputs.new_version }}
           delete-branch: true
 
       - name: Commit Changes (Direct)
@@ -148,15 +89,15 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add ${{ env.PROJECT_PATH }}
-          git commit -m "chore: bump version to ${{ steps.new-version.outputs.new_version }}"
+          git commit -m "chore: bump version to ${{ steps.git-version.outputs.new_version }}"
           git push
 
       - name: Output Summary
         run: |
           echo "## Version Update Summary"
           echo "**Previous Version**: ${{ steps.current-version.outputs.current_version }}"
-          echo "**New Version**: ${{ steps.new-version.outputs.new_version }}"
-          echo "**Version Type**: ${{ steps.new-version.outputs.version_type }}"
+          echo "**New Version**: ${{ steps.git-version.outputs.new_version }}"
+          echo "**Version Type**: ${{ steps.git-version.outputs.version_type }}"
           if [[ "${{ github.event.inputs.create_pr }}" == "true" ]]; then
             echo "**Action**: Pull request created"
           else

--- a/USAGE.md
+++ b/USAGE.md
@@ -163,12 +163,10 @@ Lists existing YouTube broadcasts.
 - `-f, --file <path>`: Path to broadcast configuration JSON file
 
 **Optional Options**:
-- `--upcoming`: Filter to show only upcoming broadcasts
-- `--active`: Filter to show only active broadcasts
-- `--completed`: Filter to show only completed broadcasts
+- `--filter <value>`: Filter broadcasts by status. Options: `All` (default), `Upcoming`, `Active`, `Completed`. Can specify multiple values (e.g., `--filter Upcoming Active` or `--filter Upcoming --filter Active`).
 - `-n, --limit <int>`: Limit the number of broadcasts returned. Default: 100. Results are sorted by most recent first (ScheduledStartTime descending).
 
-**Note**: If no filter flag is specified, all broadcasts will be listed (default behavior).
+**Note**: If no filter is specified, all broadcasts will be listed (default behavior). When multiple filters are specified, broadcasts matching any of the filters will be included.
 
 **Output Format**:
 
@@ -185,13 +183,19 @@ Broadcast Title (privacyStatus): broadcastUrl
 ./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json"
 
 # List only upcoming broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --upcoming
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Upcoming
 
 # List completed broadcasts with custom limit
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --completed -n 50
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Completed -n 50
 
 # List active broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --active
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Active
+
+# List both upcoming and active broadcasts
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Upcoming Active
+
+# Alternative syntax for multiple filters
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Upcoming --filter Active
 ```
 
 ### Update Command

--- a/USAGE.md
+++ b/USAGE.md
@@ -163,7 +163,7 @@ Lists existing YouTube broadcasts.
 - `-f, --file <path>`: Path to broadcast configuration JSON file
 
 **Optional Options**:
-- `-f, --filter <value>`: Filter broadcasts by status. Options: `all` (default), `upcoming`, `active`, `completed`
+- `-s, --filter <value>`: Filter broadcasts by status. Options: `all` (default), `upcoming`, `active`, `completed`
 - `-n, --limit <int>`: Limit the number of broadcasts returned. Default: 100. Results are sorted by most recent first (ScheduledStartTime descending).
 
 **Output Format**:
@@ -181,13 +181,13 @@ Broadcast Title (privacyStatus): broadcastUrl
 ./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json"
 
 # List only upcoming broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter upcoming
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" -s upcoming
 
 # List completed broadcasts with custom limit
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter completed --limit 50
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" -s completed -n 50
 
 # List active broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter active
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" -s active
 ```
 
 ### Update Command

--- a/USAGE.md
+++ b/USAGE.md
@@ -104,12 +104,12 @@ Download the latest release from the [GitHub Releases](https://github.com/hpract
 
 ## Commands Overview
 
-| Command  | Description               | Key Options                  |
-| -------- | ------------------------- | ---------------------------- |
-| `create` | Create YouTube broadcasts | `-f`, `-c`, `-u`, `-t`       |
-| `list`   | List existing broadcasts  | `-f`, `-c`, `-u`, `-p`       |
-| `update` | Update broadcast settings | `-y`, `-f`, `-a`, `-o`, `-p` |
-| `end`    | End active broadcasts     | `-i`                         |
+| Command  | Description               | Key Options                           |
+| -------- | ------------------------- | ------------------------------------- |
+| `create` | Create YouTube broadcasts | `-f`, `-c`, `-u`, `-t`                |
+| `list`   | List existing broadcasts  | `-f`, `-c`, `-u`, `--upcoming`, `-n`  |
+| `update` | Update broadcast settings | `-y`, `-f`, `-a`, `-o`, `-p`          |
+| `end`    | End active broadcasts     | `-i`                                  |
 
 ## Command Details
 
@@ -163,8 +163,12 @@ Lists existing YouTube broadcasts.
 - `-f, --file <path>`: Path to broadcast configuration JSON file
 
 **Optional Options**:
-- `-s, --filter <value>`: Filter broadcasts by status. Options: `all` (default), `upcoming`, `active`, `completed`
+- `--upcoming`: Filter to show only upcoming broadcasts
+- `--active`: Filter to show only active broadcasts
+- `--completed`: Filter to show only completed broadcasts
 - `-n, --limit <int>`: Limit the number of broadcasts returned. Default: 100. Results are sorted by most recent first (ScheduledStartTime descending).
+
+**Note**: If no filter flag is specified, all broadcasts will be listed (default behavior).
 
 **Output Format**:
 
@@ -181,13 +185,13 @@ Broadcast Title (privacyStatus): broadcastUrl
 ./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json"
 
 # List only upcoming broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" -s upcoming
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --upcoming
 
 # List completed broadcasts with custom limit
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" -s completed -n 50
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --completed -n 50
 
 # List active broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" -s active
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --active
 ```
 
 ### Update Command

--- a/USAGE.md
+++ b/USAGE.md
@@ -163,7 +163,8 @@ Lists existing YouTube broadcasts.
 - `-f, --file <path>`: Path to broadcast configuration JSON file
 
 **Optional Options**:
-- `-p, --upcoming`: List only upcoming broadcasts
+- `-f, --filter <value>`: Filter broadcasts by status. Options: `all` (default), `upcoming`, `active`, `completed`
+- `-n, --limit <int>`: Limit the number of broadcasts returned. Default: 100. Results are sorted by most recent first (ScheduledStartTime descending).
 
 **Output Format**:
 
@@ -172,15 +173,21 @@ Each broadcast entry displays the following information:
 Broadcast Title (privacyStatus): broadcastUrl
 ```
 
-**Note**: The privacy status (e.g., `public`, `private`, `unlisted`) is displayed in parentheses after the broadcast title, followed by the broadcast URL. This allows you to quickly identify the privacy setting for each broadcast.
+**Note**: The privacy status (e.g., `public`, `private`, `unlisted`) is displayed in parentheses after the broadcast title, followed by the broadcast URL. This allows you to quickly identify the privacy setting for each broadcast. Results are sorted by most recent first (ScheduledStartTime descending).
 
 **Examples**:
 ```bash
-# List all broadcasts
+# List all broadcasts (default, limit 100)
 ./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json"
 
 # List only upcoming broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" -p
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter upcoming
+
+# List completed broadcasts with custom limit
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter completed --limit 50
+
+# List active broadcasts
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter active
 ```
 
 ### Update Command

--- a/USAGE.md
+++ b/USAGE.md
@@ -163,10 +163,10 @@ Lists existing YouTube broadcasts.
 - `-f, --file <path>`: Path to broadcast configuration JSON file
 
 **Optional Options**:
-- `--filter <value>`: Filter broadcasts by status. Options: `All` (default), `Upcoming`, `Active`, `Completed`. Can specify multiple values (e.g., `--filter Upcoming Active` or `--filter Upcoming --filter Active`).
+- `--filter <value>`: Filter broadcasts by status. Options: `all` (default), `upcoming`, `active`, `completed`. Accepts comma-separated values (e.g., `--filter upcoming,active`).
 - `-n, --limit <int>`: Limit the number of broadcasts returned. Default: 100. Results are sorted by most recent first (ScheduledStartTime descending).
 
-**Note**: If no filter is specified, all broadcasts will be listed (default behavior). When multiple filters are specified, broadcasts matching any of the filters will be included.
+**Note**: If no filter is specified, all broadcasts will be listed (default behavior). When multiple filters are specified (comma-separated), broadcasts matching any of the filters will be included.
 
 **Output Format**:
 
@@ -183,19 +183,19 @@ Broadcast Title (privacyStatus): broadcastUrl
 ./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json"
 
 # List only upcoming broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Upcoming
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter upcoming
 
 # List completed broadcasts with custom limit
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Completed -n 50
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter completed -n 50
 
 # List active broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Active
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter active
 
-# List both upcoming and active broadcasts
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Upcoming Active
+# List both upcoming and active broadcasts (comma-separated)
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter upcoming,active
 
-# Alternative syntax for multiple filters
-./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter Upcoming --filter Active
+# List all three statuses
+./ytc list -u "your-youtube-user" -c "client_secrets.json" -f "broadcasts.json" --filter upcoming,active,completed
 ```
 
 ### Update Command

--- a/src/Commands/BroadcastFilter.cs
+++ b/src/Commands/BroadcastFilter.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+
+namespace YouTubeCLI.Commands
+{
+    public enum BroadcastFilter
+    {
+        All,
+        Upcoming,
+        Active,
+        Completed
+    }
+
+    public static class BroadcastFilterExtensions
+    {
+        public static string ToApiString(this BroadcastFilter filter)
+        {
+            return filter switch
+            {
+                BroadcastFilter.All => "all",
+                BroadcastFilter.Upcoming => "upcoming",
+                BroadcastFilter.Active => "active",
+                BroadcastFilter.Completed => "completed",
+                _ => "all"
+            };
+        }
+
+        public static BroadcastFilter FromString(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return BroadcastFilter.All;
+
+            var normalized = value.Trim().ToLowerInvariant();
+            return normalized switch
+            {
+                "all" => BroadcastFilter.All,
+                "upcoming" => BroadcastFilter.Upcoming,
+                "active" => BroadcastFilter.Active,
+                "completed" => BroadcastFilter.Completed,
+                _ => BroadcastFilter.All
+            };
+        }
+    }
+}
+

--- a/src/Commands/ListCommand.cs
+++ b/src/Commands/ListCommand.cs
@@ -24,10 +24,25 @@ namespace YouTubeCLI.Commands
 
         public Broadcasts broadcasts { get; set; }
 
-        [Option("-s|--filter <value>", "Filter broadcasts by status (all, upcoming, active, completed). Default: all", CommandOptionType.SingleValue)]
-        public string FilterString { get; set; } = "all";
+        [Option("--upcoming", "Filter to show only upcoming broadcasts", CommandOptionType.NoValue)]
+        public bool Upcoming { get; set; }
 
-        public BroadcastFilter Filter => BroadcastFilterExtensions.FromString(FilterString);
+        [Option("--active", "Filter to show only active broadcasts", CommandOptionType.NoValue)]
+        public bool Active { get; set; }
+
+        [Option("--completed", "Filter to show only completed broadcasts", CommandOptionType.NoValue)]
+        public bool Completed { get; set; }
+
+        public BroadcastFilter Filter
+        {
+            get
+            {
+                if (Upcoming) return BroadcastFilter.Upcoming;
+                if (Active) return BroadcastFilter.Active;
+                if (Completed) return BroadcastFilter.Completed;
+                return BroadcastFilter.All;
+            }
+        }
 
         [Option("-n|--limit <int>", "Limit the number of broadcasts returned. Default: 100", CommandOptionType.SingleValue)]
         public int Limit { get; set; } = 100;
@@ -72,10 +87,17 @@ namespace YouTubeCLI.Commands
                 _args.Add(ClientSecretsFile);
             }
 
-            if (Filter != BroadcastFilter.All)
+            if (Upcoming)
             {
-                _args.Add("filter");
-                _args.Add(Filter.ToApiString());
+                _args.Add("upcoming");
+            }
+            else if (Active)
+            {
+                _args.Add("active");
+            }
+            else if (Completed)
+            {
+                _args.Add("completed");
             }
 
             if (Limit != 100)

--- a/src/Commands/ListCommand.cs
+++ b/src/Commands/ListCommand.cs
@@ -24,7 +24,7 @@ namespace YouTubeCLI.Commands
 
         public Broadcasts broadcasts { get; set; }
 
-        [Option("-f|--filter <value>", "Filter broadcasts by status (all, upcoming, active, completed). Default: all", CommandOptionType.SingleValue)]
+        [Option("-s|--filter <value>", "Filter broadcasts by status (all, upcoming, active, completed). Default: all", CommandOptionType.SingleValue)]
         public string FilterString { get; set; } = "all";
 
         public BroadcastFilter Filter => BroadcastFilterExtensions.FromString(FilterString);

--- a/src/Commands/ListCommand.cs
+++ b/src/Commands/ListCommand.cs
@@ -24,25 +24,8 @@ namespace YouTubeCLI.Commands
 
         public Broadcasts broadcasts { get; set; }
 
-        [Option("--upcoming", "Filter to show only upcoming broadcasts", CommandOptionType.NoValue)]
-        public bool Upcoming { get; set; }
-
-        [Option("--active", "Filter to show only active broadcasts", CommandOptionType.NoValue)]
-        public bool Active { get; set; }
-
-        [Option("--completed", "Filter to show only completed broadcasts", CommandOptionType.NoValue)]
-        public bool Completed { get; set; }
-
-        public BroadcastFilter Filter
-        {
-            get
-            {
-                if (Upcoming) return BroadcastFilter.Upcoming;
-                if (Active) return BroadcastFilter.Active;
-                if (Completed) return BroadcastFilter.Completed;
-                return BroadcastFilter.All;
-            }
-        }
+        [Option("--filter <value>", "Filter broadcasts by status (All, Upcoming, Active, Completed). Default: All", CommandOptionType.SingleValue)]
+        public BroadcastFilter Filter { get; set; } = BroadcastFilter.All;
 
         [Option("-n|--limit <int>", "Limit the number of broadcasts returned. Default: 100", CommandOptionType.SingleValue)]
         public int Limit { get; set; } = 100;
@@ -87,17 +70,10 @@ namespace YouTubeCLI.Commands
                 _args.Add(ClientSecretsFile);
             }
 
-            if (Upcoming)
+            if (Filter != BroadcastFilter.All)
             {
-                _args.Add("upcoming");
-            }
-            else if (Active)
-            {
-                _args.Add("active");
-            }
-            else if (Completed)
-            {
-                _args.Add("completed");
+                _args.Add("filter");
+                _args.Add(Filter.ToString());
             }
 
             if (Limit != 100)

--- a/src/Commands/ListCommand.cs
+++ b/src/Commands/ListCommand.cs
@@ -24,8 +24,13 @@ namespace YouTubeCLI.Commands
 
         public Broadcasts broadcasts { get; set; }
 
-        [Option("-p|--upcoming", "List only upcoming broadcasts", CommandOptionType.NoValue)]
-        public bool Upcoming { get; set; }
+        [Option("-f|--filter <value>", "Filter broadcasts by status (all, upcoming, active, completed). Default: all", CommandOptionType.SingleValue)]
+        public string FilterString { get; set; } = "all";
+
+        public BroadcastFilter Filter => BroadcastFilterExtensions.FromString(FilterString);
+
+        [Option("-n|--limit <int>", "Limit the number of broadcasts returned. Default: 100", CommandOptionType.SingleValue)]
+        public int Limit { get; set; } = 100;
 
         private YouTubeCLI Parent { get; set; }
 
@@ -38,10 +43,11 @@ namespace YouTubeCLI.Commands
 
                 var _youTubeLibrary = new YouTubeLibrary(YouTubeUser, ClientSecretsFile);
                 ClearCredentialsIfRequested(_youTubeLibrary);
-                var _broadcasts = Task.Run<IEnumerable<LinkDetails>>(() => _youTubeLibrary.ListBroadcastUrls(Upcoming));
+                var _broadcasts = Task.Run<IEnumerable<LinkDetails>>(() => _youTubeLibrary.ListBroadcastUrls(Filter, Limit));
                 _broadcasts.Wait();
 
-                Console.WriteLine($"Getting{(Upcoming ? " Upcoming" : "")} Broadcasts.");
+                var filterText = Filter == BroadcastFilter.All ? "" : $" {Filter}";
+                Console.WriteLine($"Getting{filterText} Broadcasts{(Limit != 100 ? $" (limit: {Limit})" : "")}.");
                 foreach (var _broadcast in _broadcasts.Result)
                 {
                     Console.WriteLine($"{_broadcast.title} ({_broadcast.privacyStatus}): {_broadcast.broadcastUrl}");
@@ -66,9 +72,16 @@ namespace YouTubeCLI.Commands
                 _args.Add(ClientSecretsFile);
             }
 
-            if (Upcoming)
+            if (Filter != BroadcastFilter.All)
             {
-                _args.Add("upcoming");
+                _args.Add("filter");
+                _args.Add(Filter.ToApiString());
+            }
+
+            if (Limit != 100)
+            {
+                _args.Add("limit");
+                _args.Add(Limit.ToString());
             }
             return _args;
         }

--- a/src/Libraries/YouTubeLibrary.cs
+++ b/src/Libraries/YouTubeLibrary.cs
@@ -319,6 +319,37 @@ namespace YouTubeCLI.Libraries
             return linkDetails;
         }
 
+        public async Task<IEnumerable<LinkDetails>> ListBroadcastUrls(IEnumerable<BroadcastFilter> filters, int limit = 100)
+        {
+            if (filters == null || !filters.Any())
+            {
+                filters = new[] { BroadcastFilter.All };
+            }
+
+            // If All is specified, just use that
+            if (filters.Contains(BroadcastFilter.All))
+            {
+                return await ListBroadcastUrls(BroadcastFilter.All, limit);
+            }
+
+            // Fetch broadcasts for each filter and combine
+            var allBroadcasts = new List<LinkDetails>();
+            foreach (var filter in filters.Distinct())
+            {
+                var broadcasts = await ListBroadcastUrls(filter, limit);
+                allBroadcasts.AddRange(broadcasts);
+            }
+
+            // Remove duplicates and apply limit
+            var linkDetails = allBroadcasts
+                .GroupBy(b => b.id)
+                .Select(g => g.First())
+                .OrderByDescending(b => b.title)
+                .Take(limit);
+
+            return linkDetails;
+        }
+
         public async Task<IEnumerable<LinkDetails>> ListUpcomingBroadcastUrls()
             => await ListBroadcastUrls(BroadcastFilter.Upcoming);
     }

--- a/src/Libraries/YouTubeLibrary.cs
+++ b/src/Libraries/YouTubeLibrary.cs
@@ -276,23 +276,20 @@ namespace YouTubeCLI.Libraries
             _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.All;
 
             // Map string to enum
-            if (broadcastStatus != null)
+            switch (broadcastStatus.ToLowerInvariant())
             {
-                switch (broadcastStatus.ToLowerInvariant())
-                {
-                    case "all":
-                        _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.All;
-                        break;
-                    case "upcoming":
-                        _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.Upcoming;
-                        break;
-                    case "active":
-                        _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.Active;
-                        break;
-                    case "completed":
-                        _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.Completed;
-                        break;
-                }
+                case "all":
+                    _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.All;
+                    break;
+                case "upcoming":
+                    _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.Upcoming;
+                    break;
+                case "active":
+                    _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.Active;
+                    break;
+                case "completed":
+                    _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.Completed;
+                    break;
             }
 
             var _broadcasts = await _listRequest.ExecuteAsync();
@@ -307,7 +304,7 @@ namespace YouTubeCLI.Libraries
 
             var linkDetails = broadcasts
                 .OrderByDescending(b => b.Snippet?.ScheduledStartTime ?? DateTime.MinValue)
-                .ThenBy(b => b.Snippet?.ScheduledStartTime == null ? 0 : 1) // Put nulls last
+                .ThenBy(b => b.Snippet?.ScheduledStartTime == null ? 1 : 0) // Put nulls last
                 .Take(limit)
                 .Select(b => new LinkDetails
                 {

--- a/src/YouTubeCLI.csproj
+++ b/src/YouTubeCLI.csproj
@@ -7,10 +7,10 @@
     <StartupObject>YouTubeCLI.YouTubeCLI</StartupObject>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <Version>1.0.9</Version>
-    <AssemblyVersion>1.0.9.0</AssemblyVersion>
-    <FileVersion>1.0.9.0</FileVersion>
-    <InformationalVersion>1.0.9</InformationalVersion>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+    <InformationalVersion>2.0.0</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/YouTubeCLI.Tests/Commands/CommandLineIntegrationTests.cs
+++ b/tests/YouTubeCLI.Tests/Commands/CommandLineIntegrationTests.cs
@@ -140,7 +140,7 @@ namespace YouTubeCLI.Tests.Commands
             command.YouTubeUser.Should().Be("test-user");
             command.ClientSecretsFile.Should().Be("secrets.json");
             command.BroadcastFile.Should().Be("broadcasts.json");
-            command.Filter.Should().Be(BroadcastFilter.All);
+            command.Filter.Should().BeEquivalentTo(new[] { BroadcastFilter.All });
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace YouTubeCLI.Tests.Commands
             command.YouTubeUser.Should().Be("test-user");
             command.ClientSecretsFile.Should().Be("secrets.json");
             command.BroadcastFile.Should().Be("broadcasts.json");
-            command.Filter.Should().Be(BroadcastFilter.Upcoming);
+            command.Filter.Should().BeEquivalentTo(new[] { BroadcastFilter.Upcoming });
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace YouTubeCLI.Tests.Commands
             command.YouTubeUser.Should().Be("test-user");
             command.ClientSecretsFile.Should().Be("secrets.json");
             command.BroadcastFile.Should().Be("broadcasts.json");
-            command.Filter.Should().Be(BroadcastFilter.Upcoming);
+            command.Filter.Should().BeEquivalentTo(new[] { BroadcastFilter.Upcoming });
         }
 
         [Fact]

--- a/tests/YouTubeCLI.Tests/Commands/CommandLineIntegrationTests.cs
+++ b/tests/YouTubeCLI.Tests/Commands/CommandLineIntegrationTests.cs
@@ -133,32 +133,32 @@ namespace YouTubeCLI.Tests.Commands
             command.YouTubeUser = "test-user";
             command.ClientSecretsFile = "secrets.json";
             command.BroadcastFile = "broadcasts.json";
-            command.Upcoming = false;
+            command.FilterString = "all";
 
             // Act & Assert
             command.Should().NotBeNull();
             command.YouTubeUser.Should().Be("test-user");
             command.ClientSecretsFile.Should().Be("secrets.json");
             command.BroadcastFile.Should().Be("broadcasts.json");
-            command.Upcoming.Should().BeFalse();
+            command.Filter.Should().Be(BroadcastFilter.All);
         }
 
         [Fact]
-        public void ListCommand_WithUpcomingFlag_ShouldParseCorrectly()
+        public void ListCommand_WithFilterFlag_ShouldParseCorrectly()
         {
             // Arrange
             var command = new ListCommand();
             command.YouTubeUser = "test-user";
             command.ClientSecretsFile = "secrets.json";
             command.BroadcastFile = "broadcasts.json";
-            command.Upcoming = true;
+            command.FilterString = "upcoming";
 
             // Act & Assert
             command.Should().NotBeNull();
             command.YouTubeUser.Should().Be("test-user");
             command.ClientSecretsFile.Should().Be("secrets.json");
             command.BroadcastFile.Should().Be("broadcasts.json");
-            command.Upcoming.Should().BeTrue();
+            command.Filter.Should().Be(BroadcastFilter.Upcoming);
         }
 
         [Fact]
@@ -169,14 +169,14 @@ namespace YouTubeCLI.Tests.Commands
             command.YouTubeUser = "test-user";
             command.ClientSecretsFile = "secrets.json";
             command.BroadcastFile = "broadcasts.json";
-            command.Upcoming = true;
+            command.FilterString = "upcoming";
 
             // Act & Assert
             command.Should().NotBeNull();
             command.YouTubeUser.Should().Be("test-user");
             command.ClientSecretsFile.Should().Be("secrets.json");
             command.BroadcastFile.Should().Be("broadcasts.json");
-            command.Upcoming.Should().BeTrue();
+            command.Filter.Should().Be(BroadcastFilter.Upcoming);
         }
 
         [Fact]

--- a/tests/YouTubeCLI.Tests/Commands/CommandLineParsingTests.cs
+++ b/tests/YouTubeCLI.Tests/Commands/CommandLineParsingTests.cs
@@ -188,12 +188,15 @@ namespace YouTubeCLI.Tests.Commands
             var commandType = typeof(ListCommand);
 
             // Act & Assert
-            var upcomingProperty = commandType.GetProperty(nameof(ListCommand.Upcoming));
+            var filterProperty = commandType.GetProperty(nameof(ListCommand.FilterString));
+            var limitProperty = commandType.GetProperty(nameof(ListCommand.Limit));
 
-            upcomingProperty.Should().NotBeNull();
+            filterProperty.Should().NotBeNull();
+            limitProperty.Should().NotBeNull();
 
-            // This should not have Required attribute
-            upcomingProperty!.GetCustomAttribute<System.ComponentModel.DataAnnotations.RequiredAttribute>().Should().BeNull();
+            // These should not have Required attribute
+            filterProperty!.GetCustomAttribute<System.ComponentModel.DataAnnotations.RequiredAttribute>().Should().BeNull();
+            limitProperty!.GetCustomAttribute<System.ComponentModel.DataAnnotations.RequiredAttribute>().Should().BeNull();
         }
     }
 }

--- a/tests/YouTubeCLI.Tests/Commands/EdgeCaseTests.cs
+++ b/tests/YouTubeCLI.Tests/Commands/EdgeCaseTests.cs
@@ -217,7 +217,7 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                Upcoming = false
+                FilterString = "all"
             };
 
             // Act

--- a/tests/YouTubeCLI.Tests/Commands/ListCommandTests.cs
+++ b/tests/YouTubeCLI.Tests/Commands/ListCommandTests.cs
@@ -48,7 +48,7 @@ namespace YouTubeCLI.Tests.Commands
         }
 
         [Fact]
-        public void CreateArgs_WithUpcomingFlag_ShouldIncludeUpcomingFlag()
+        public void CreateArgs_WithUpcomingFilter_ShouldIncludeUpcomingFilter()
         {
             // Arrange
             var command = new ListCommand
@@ -56,34 +56,34 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                Upcoming = true
+                Filter = new[] { BroadcastFilter.Upcoming }
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("upcoming");
+            args.Should().Contain("filter");
+            args.Should().Contain("Upcoming");
         }
 
         [Fact]
-        public void CreateArgs_WithNoFilterFlags_ShouldNotIncludeAnyFilterFlag()
+        public void CreateArgs_WithDefaultFilter_ShouldNotIncludeFilterFlag()
         {
             // Arrange
             var command = new ListCommand
             {
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
-                BroadcastFile = "broadcasts.json"
+                BroadcastFile = "broadcasts.json",
+                Filter = new[] { BroadcastFilter.All }
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().NotContain("upcoming");
-            args.Should().NotContain("active");
-            args.Should().NotContain("completed");
+            args.Should().NotContain("filter");
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                Upcoming = true,
+                Filter = new[] { BroadcastFilter.Upcoming },
                 Limit = 50
             };
 
@@ -141,7 +141,8 @@ namespace YouTubeCLI.Tests.Commands
             // Assert
             args.Should().Contain("client-secrets");
             args.Should().Contain("secrets.json");
-            args.Should().Contain("upcoming");
+            args.Should().Contain("filter");
+            args.Should().Contain("Upcoming");
             args.Should().Contain("limit");
             args.Should().Contain("50");
         }
@@ -155,7 +156,7 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "user123",
                 ClientSecretsFile = "my-secrets.json",
                 BroadcastFile = "my-broadcasts.json",
-                Upcoming = true,
+                Filter = new[] { BroadcastFilter.Upcoming },
                 Limit = 50
             };
 
@@ -163,8 +164,8 @@ namespace YouTubeCLI.Tests.Commands
             command.YouTubeUser.Should().Be("user123");
             command.ClientSecretsFile.Should().Be("my-secrets.json");
             command.BroadcastFile.Should().Be("my-broadcasts.json");
-            command.Upcoming.Should().BeTrue();
-            command.Filter.Should().Be(BroadcastFilter.Upcoming);
+            command.Filter.Should().ContainSingle();
+            command.Filter[0].Should().Be(BroadcastFilter.Upcoming);
             command.Limit.Should().Be(50);
         }
 
@@ -175,10 +176,8 @@ namespace YouTubeCLI.Tests.Commands
             var command = new ListCommand();
 
             // Assert
-            command.Filter.Should().Be(BroadcastFilter.All);
-            command.Upcoming.Should().BeFalse();
-            command.Active.Should().BeFalse();
-            command.Completed.Should().BeFalse();
+            command.Filter.Should().ContainSingle();
+            command.Filter[0].Should().Be(BroadcastFilter.All);
         }
 
         [Fact]
@@ -411,27 +410,23 @@ namespace YouTubeCLI.Tests.Commands
             value.Should().BeFalse();
         }
 
-        [Theory]
-        [InlineData(false, false, false, BroadcastFilter.All)]
-        [InlineData(true, false, false, BroadcastFilter.Upcoming)]
-        [InlineData(false, true, false, BroadcastFilter.Active)]
-        [InlineData(false, false, true, BroadcastFilter.Completed)]
-        public void ListCommand_Filter_ShouldReturnCorrectFilter(bool upcoming, bool active, bool completed, BroadcastFilter expectedFilter)
+        [Fact]
+        public void ListCommand_Filter_ShouldAcceptMultipleValues()
         {
             // Arrange & Act
             var command = new ListCommand
             {
-                Upcoming = upcoming,
-                Active = active,
-                Completed = completed
+                Filter = new[] { BroadcastFilter.Upcoming, BroadcastFilter.Active }
             };
 
             // Assert
-            command.Filter.Should().Be(expectedFilter);
+            command.Filter.Should().HaveCount(2);
+            command.Filter.Should().Contain(BroadcastFilter.Upcoming);
+            command.Filter.Should().Contain(BroadcastFilter.Active);
         }
 
         [Fact]
-        public void CreateArgs_WithActiveFlag_ShouldIncludeActiveFlag()
+        public void CreateArgs_WithActiveFilter_ShouldIncludeActiveFilter()
         {
             // Arrange
             var command = new ListCommand
@@ -439,18 +434,19 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                Active = true
+                Filter = new[] { BroadcastFilter.Active }
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("active");
+            args.Should().Contain("filter");
+            args.Should().Contain("Active");
         }
 
         [Fact]
-        public void CreateArgs_WithCompletedFlag_ShouldIncludeCompletedFlag()
+        public void CreateArgs_WithCompletedFilter_ShouldIncludeCompletedFilter()
         {
             // Arrange
             var command = new ListCommand
@@ -458,14 +454,15 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                Completed = true
+                Filter = new[] { BroadcastFilter.Completed }
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("completed");
+            args.Should().Contain("filter");
+            args.Should().Contain("Completed");
         }
 
         [Fact]
@@ -532,7 +529,7 @@ namespace YouTubeCLI.Tests.Commands
         }
 
         [Fact]
-        public void CreateArgs_WithCompletedFlagAndLimit_ShouldIncludeBoth()
+        public void CreateArgs_WithCompletedFilterAndLimit_ShouldIncludeBoth()
         {
             // Arrange
             var command = new ListCommand
@@ -540,7 +537,7 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                Completed = true,
+                Filter = new[] { BroadcastFilter.Completed },
                 Limit = 25
             };
 
@@ -548,9 +545,34 @@ namespace YouTubeCLI.Tests.Commands
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("completed");
+            args.Should().Contain("filter");
+            args.Should().Contain("Completed");
             args.Should().Contain("limit");
             args.Should().Contain("25");
+        }
+
+        [Fact]
+        public void CreateArgs_WithMultipleFilters_ShouldIncludeAllFilters()
+        {
+            // Arrange
+            var command = new ListCommand
+            {
+                YouTubeUser = "test-user",
+                ClientSecretsFile = "secrets.json",
+                BroadcastFile = "broadcasts.json",
+                Filter = new[] { BroadcastFilter.Upcoming, BroadcastFilter.Active }
+            };
+
+            // Act
+            var args = command.CreateArgs();
+
+            // Assert
+            var filterIndices = args.Select((arg, index) => arg == "filter" ? index : -1)
+                .Where(index => index >= 0)
+                .ToList();
+            filterIndices.Should().HaveCount(2);
+            args.Should().Contain("Upcoming");
+            args.Should().Contain("Active");
         }
     }
 }

--- a/tests/YouTubeCLI.Tests/Commands/ListCommandTests.cs
+++ b/tests/YouTubeCLI.Tests/Commands/ListCommandTests.cs
@@ -48,7 +48,7 @@ namespace YouTubeCLI.Tests.Commands
         }
 
         [Fact]
-        public void CreateArgs_WithFilterUpcoming_ShouldIncludeFilterFlag()
+        public void CreateArgs_WithUpcomingFlag_ShouldIncludeUpcomingFlag()
         {
             // Arrange
             var command = new ListCommand
@@ -56,34 +56,34 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                FilterString = "upcoming"
+                Upcoming = true
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("filter");
             args.Should().Contain("upcoming");
         }
 
         [Fact]
-        public void CreateArgs_WithFilterAll_ShouldNotIncludeFilterFlag()
+        public void CreateArgs_WithNoFilterFlags_ShouldNotIncludeAnyFilterFlag()
         {
             // Arrange
             var command = new ListCommand
             {
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
-                BroadcastFile = "broadcasts.json",
-                FilterString = "all"
+                BroadcastFile = "broadcasts.json"
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().NotContain("filter");
+            args.Should().NotContain("upcoming");
+            args.Should().NotContain("active");
+            args.Should().NotContain("completed");
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                FilterString = "upcoming",
+                Upcoming = true,
                 Limit = 50
             };
 
@@ -141,7 +141,6 @@ namespace YouTubeCLI.Tests.Commands
             // Assert
             args.Should().Contain("client-secrets");
             args.Should().Contain("secrets.json");
-            args.Should().Contain("filter");
             args.Should().Contain("upcoming");
             args.Should().Contain("limit");
             args.Should().Contain("50");
@@ -156,7 +155,7 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "user123",
                 ClientSecretsFile = "my-secrets.json",
                 BroadcastFile = "my-broadcasts.json",
-                FilterString = "upcoming",
+                Upcoming = true,
                 Limit = 50
             };
 
@@ -164,6 +163,7 @@ namespace YouTubeCLI.Tests.Commands
             command.YouTubeUser.Should().Be("user123");
             command.ClientSecretsFile.Should().Be("my-secrets.json");
             command.BroadcastFile.Should().Be("my-broadcasts.json");
+            command.Upcoming.Should().BeTrue();
             command.Filter.Should().Be(BroadcastFilter.Upcoming);
             command.Limit.Should().Be(50);
         }
@@ -176,7 +176,9 @@ namespace YouTubeCLI.Tests.Commands
 
             // Assert
             command.Filter.Should().Be(BroadcastFilter.All);
-            command.FilterString.Should().Be("all");
+            command.Upcoming.Should().BeFalse();
+            command.Active.Should().BeFalse();
+            command.Completed.Should().BeFalse();
         }
 
         [Fact]
@@ -410,19 +412,18 @@ namespace YouTubeCLI.Tests.Commands
         }
 
         [Theory]
-        [InlineData("all", BroadcastFilter.All)]
-        [InlineData("upcoming", BroadcastFilter.Upcoming)]
-        [InlineData("active", BroadcastFilter.Active)]
-        [InlineData("completed", BroadcastFilter.Completed)]
-        [InlineData("ALL", BroadcastFilter.All)]
-        [InlineData("Upcoming", BroadcastFilter.Upcoming)]
-        [InlineData("  active  ", BroadcastFilter.Active)]
-        public void ListCommand_Filter_ShouldParseCorrectly(string filterString, BroadcastFilter expectedFilter)
+        [InlineData(false, false, false, BroadcastFilter.All)]
+        [InlineData(true, false, false, BroadcastFilter.Upcoming)]
+        [InlineData(false, true, false, BroadcastFilter.Active)]
+        [InlineData(false, false, true, BroadcastFilter.Completed)]
+        public void ListCommand_Filter_ShouldReturnCorrectFilter(bool upcoming, bool active, bool completed, BroadcastFilter expectedFilter)
         {
             // Arrange & Act
             var command = new ListCommand
             {
-                FilterString = filterString
+                Upcoming = upcoming,
+                Active = active,
+                Completed = completed
             };
 
             // Assert
@@ -430,7 +431,7 @@ namespace YouTubeCLI.Tests.Commands
         }
 
         [Fact]
-        public void CreateArgs_WithFilterActive_ShouldIncludeFilterFlag()
+        public void CreateArgs_WithActiveFlag_ShouldIncludeActiveFlag()
         {
             // Arrange
             var command = new ListCommand
@@ -438,19 +439,18 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                FilterString = "active"
+                Active = true
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("filter");
             args.Should().Contain("active");
         }
 
         [Fact]
-        public void CreateArgs_WithFilterCompleted_ShouldIncludeFilterFlag()
+        public void CreateArgs_WithCompletedFlag_ShouldIncludeCompletedFlag()
         {
             // Arrange
             var command = new ListCommand
@@ -458,14 +458,13 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                FilterString = "completed"
+                Completed = true
             };
 
             // Act
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("filter");
             args.Should().Contain("completed");
         }
 
@@ -533,7 +532,7 @@ namespace YouTubeCLI.Tests.Commands
         }
 
         [Fact]
-        public void CreateArgs_WithFilterAndLimit_ShouldIncludeBoth()
+        public void CreateArgs_WithCompletedFlagAndLimit_ShouldIncludeBoth()
         {
             // Arrange
             var command = new ListCommand
@@ -541,7 +540,7 @@ namespace YouTubeCLI.Tests.Commands
                 YouTubeUser = "test-user",
                 ClientSecretsFile = "secrets.json",
                 BroadcastFile = "broadcasts.json",
-                FilterString = "completed",
+                Completed = true,
                 Limit = 25
             };
 
@@ -549,7 +548,6 @@ namespace YouTubeCLI.Tests.Commands
             var args = command.CreateArgs();
 
             // Assert
-            args.Should().Contain("filter");
             args.Should().Contain("completed");
             args.Should().Contain("limit");
             args.Should().Contain("25");


### PR DESCRIPTION
- FEAT: enhance list command with filtering and limiting options
- Updated the list command to include a `--filter` option for broadcast status (all, upcoming, active, completed).
- Introduced a `--limit` option to specify the number of broadcasts returned, defaulting to 100.
- Adjusted the output format to reflect the applied filters and limits.
- Bumped version to 2.0.0 and updated related project files accordingly.
- +semver:breaking


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `--filter` and `--limit` to `list`, updates library to support filtered/sorted retrieval, refreshes docs/tests, bumps to 2.0.0, and switches CI versioning to git-version-lite.
> 
> - **CLI - `list` command**:
>   - Add `--filter` (supports `all`, `upcoming`, `active`, `completed`, comma-separated) and `-n|--limit` (default 100).
>   - Update output to reflect applied filters/limits and args creation logic.
> - **Library**:
>   - Introduce `BroadcastFilter` + parsing helpers.
>   - Extend `YouTubeLibrary.ListBroadcasts/ListBroadcastUrls` to accept status filters, combine multiple filters, de-duplicate, and sort by `ScheduledStartTime` desc (nulls last).
> - **Docs/Tests**:
>   - Update `USAGE.md` with new options and examples.
>   - Revise and expand tests for filter parsing, limits, and arg generation.
> - **Versioning**:
>   - Bump project version to `2.0.0`.
>   - CI: use `im-open/git-version-lite` with full fetch depth; propagate outputs to PR commit/title/body.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cda395141b8f3a153740798d752178d699adcf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->