### PR TITLE
Fix YouTube API incompatible parameters error in ListBroadcasts

### DIFF
--- a/src/Libraries/YouTubeLibrary.cs
+++ b/src/Libraries/YouTubeLibrary.cs
@@ -272,14 +272,16 @@ namespace YouTubeCLI.Libraries
         public async Task<IEnumerable<LiveBroadcast>> ListBroadcasts(string parts = _broadcastPart, string broadcastStatus = "all")
         {
             var _listRequest = service.LiveBroadcasts.List(_broadcastPart);
-            _listRequest.Mine = true;
-            _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.All;
-
-            // Map string to enum
+            
+            // Note: According to YouTube API docs, Mine and BroadcastStatus parameters are incompatible
+            // When BroadcastStatus is not "all", we use BroadcastStatus parameter
+            // When BroadcastStatus is "all", we use Mine parameter instead
+            
             switch (broadcastStatus.ToLowerInvariant())
             {
                 case "all":
-                    _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.All;
+                    // Use Mine instead of BroadcastStatus for "all"
+                    _listRequest.Mine = true;
                     break;
                 case "upcoming":
                     _listRequest.BroadcastStatus = Google.Apis.YouTube.v3.LiveBroadcastsResource.ListRequest.BroadcastStatusEnum.Upcoming;


### PR DESCRIPTION
## Problem
The YouTube API was returning a BadRequest error when listing broadcasts with status filters:
```
Error Listing Broadcasts: One or more errors occurred. (The service youtube has thrown an exception. HttpStatusCode is BadRequest. Incompatible parameters specified in the request: broadcastStatus, mine)
```

This was caused by the `ListBroadcasts` method setting both `Mine=true` and `BroadcastStatus` parameters simultaneously, which are incompatible according to YouTube's API documentation.

## Solution
Modified the `ListBroadcasts` method in `YouTubeLibrary.cs` to:
- Use `Mine=true` only when `broadcastStatus` is "all"
- Use `BroadcastStatus` parameter for specific statuses (upcoming, active, completed)
- Never set both parameters at the same time

## Testing
Verified the fix works correctly:
- `ytc list --filter upcoming` - ✅ Works
- `ytc list --filter all` - ✅ Works
- `ytc list --filter active` - ✅ Works
- `ytc list --filter completed` - ✅ Works

## Changes
- Modified `src/Libraries/YouTubeLibrary.cs`
  - Removed unconditional `Mine=true` assignment
  - Added logic to set either `Mine` or `BroadcastStatus` based on filter value
  - Added explanatory comments about API parameter incompatibility