### PR TITLE
Refactor async methods and fix privacy option

### DIFF
--- a/src/Commands/UpdateCommand.cs
+++ b/src/Commands/UpdateCommand.cs
@@ -40,7 +40,7 @@ namespace YouTubeCLI.Commands
         public bool? AutoStop { get; set; }
 
         [Option("-p|--privacy", "Set privacy to public, unlisted, or private",
-            CommandOptionType.SingleOrNoValue)]
+            CommandOptionType.SingleValue)]
         public PrivacyEnum? Privacy { get; set; }
 
         [Option("-e|--chat-enabled <value>", "Set chat enabled to true or false",

--- a/src/Libraries/YouTubeLibrary.cs
+++ b/src/Libraries/YouTubeLibrary.cs
@@ -267,7 +267,7 @@ namespace YouTubeCLI.Libraries
                 var response = await _thumbnailRequest.UploadAsync();
                 if (response.Status == Google.Apis.Upload.UploadStatus.Failed)
                 {
-                     Console.WriteLine($"Thumbnail upload failed: {response.Exception?.Message}");
+                     throw new Exception($"Thumbnail upload failed: {response.Exception?.Message}");
                 }
             }
         }

--- a/src/Libraries/YouTubeLibrary.cs
+++ b/src/Libraries/YouTubeLibrary.cs
@@ -229,8 +229,6 @@ namespace YouTubeCLI.Libraries
                 _broadcast.Status.SelfDeclaredMadeForKids = !chatEnabled.Value;
             }
 
-
-
             var _updateRequest = (await GetServiceAsync()).LiveBroadcasts.Update(_broadcast, _broadcastPart);
             await _updateRequest.ExecuteAsync();
         }


### PR DESCRIPTION
## Changes
- Convert synchronous service/streams properties to async methods (GetServiceAsync, GetLiveStreamsAsync)
- Remove Task.Run().Result anti-patterns and replace with proper await
- Add caching for live streams to improve performance
- Add error handling for thumbnail upload failures
- Fix privacy command option to require a value (SingleValue instead of SingleOrNoValue)

## Motivation
This refactor improves the async/await patterns in the codebase by removing blocking calls and properly awaiting async operations. This will prevent potential deadlocks and improve overall application performance.